### PR TITLE
Add support for Specular Workflow

### DIFF
--- a/Assets/BrokenVector/LowPolyShaders/Shaders/LowPolyPBRSpecular.shader
+++ b/Assets/BrokenVector/LowPolyShaders/Shaders/LowPolyPBRSpecular.shader
@@ -1,0 +1,49 @@
+Shader "LowPolyShaders/LowPolyPBRSpecular"
+{
+	Properties
+	{
+		_MainTex ("Albedo", 2D) = "white" {}
+		_Color ("Albedo Tint", Color) = (1,1,1,1)
+		_Specular ("Specular (RGB: Spec, A: Gloss)", 2D) = "white" {}
+		_SpecTint ("Specular Tint", Color) = (0,0,0,0)
+	}
+
+	SubShader
+	{
+		Tags { "RenderType"="Opaque" }
+		LOD 200
+
+		CGPROGRAM
+
+		#pragma surface surf StandardSpecular fullforwardshadows vertex:vert
+		#pragma target 3.0
+
+		struct Input
+		{
+			half3 color;
+			half4 specular;
+		};
+
+		sampler2D _MainTex;
+		sampler2D _Specular;
+		fixed4 _Color;
+		fixed4 _SpecTint;
+
+		void vert (inout appdata_full v, out Input o)
+		{
+			o.color = tex2Dlod(_MainTex, v.texcoord) * _Color;
+			o.specular = tex2Dlod(_Specular, v.texcoord) * _SpecTint;
+		}
+
+		void surf (Input IN, inout SurfaceOutputStandardSpecular o)
+		{
+			o.Albedo = IN.color;
+			// specular color
+			o.Specular = IN.specular;
+			// smoothness from alpha component of specularity texture
+			o.Smoothness = IN.specular.a;
+		}
+		ENDCG
+	}
+	FallBack "Diffuse"
+}


### PR DESCRIPTION
Added support for the Specular/Gloss workflow for those who prefer it :)

Create a modified version of the low poly shader to use the StandardSpecular workflow.
The RGB component from the Specular Texture is mapped to the Specular color, and
the Alpha component is mapped to Smoothness.